### PR TITLE
Fix contract test for `Dynatracece::Environment::SyntheticMonitor`

### DIFF
--- a/Dynatrace-Common/src/abstract-base-resource.ts
+++ b/Dynatrace-Common/src/abstract-base-resource.ts
@@ -19,7 +19,7 @@ export interface RetryableCallbackContext {
 
 export abstract class AbstractBaseResource<ResourceModelType extends BaseModel, GetResponseData, CreateResponseData, UpdateResponseData, ErrorType, TypeConfigurationType> extends BaseResource<ResourceModelType> {
 
-    private maxRetries = 5;
+    protected maxRetries = 5;
 
     /**
      * This method is invoked to get a resource from a vendor API, corresponding to the given the CloudFormation model input.
@@ -319,7 +319,7 @@ export abstract class AbstractBaseResource<ResourceModelType extends BaseModel, 
         }
     }
 
-    private async assertExists(model: ResourceModelType, typeConfiguration: TypeConfigurationType) {
+    protected async assertExists(model: ResourceModelType, typeConfiguration: TypeConfigurationType) {
         try {
             await this.get(model, typeConfiguration);
         } catch (e) {

--- a/Dynatrace-Environment-SyntheticMonitor/dynatrace-environment-syntheticmonitor.json
+++ b/Dynatrace-Environment-SyntheticMonitor/dynatrace-environment-syntheticmonitor.json
@@ -321,9 +321,6 @@
     }
   },
   "additionalProperties": false,
-  "tagging": {
-    "taggable": true
-  },
   "required": [
     "FrequencyMin",
     "Type",
@@ -331,7 +328,10 @@
     "Enabled"
   ],
   "writeOnlyProperties": [
-    "/properties/Type"
+    "/properties/Type",
+    "/properties/AnomalyDetection",
+    "/properties/Script",
+    "/properties/Tags"
   ],
   "readOnlyProperties": [
     "/properties/EntityId",

--- a/Dynatrace-Environment-SyntheticMonitor/src/handlers.ts
+++ b/Dynatrace-Environment-SyntheticMonitor/src/handlers.ts
@@ -1,8 +1,19 @@
 import {ResourceModel, TypeConfigurationModel} from './models';
+import {RetryableCallbackContext} from '../../Dynatrace-Common/src/abstract-base-resource';
 import {AbstractDynatraceResource} from '../../Dynatrace-Common/src/abstract-dynatrace-resource';
 import {DynatraceClient} from '../../Dynatrace-Common/src/dynatrace-client';
 import {CaseTransformer, Transformer} from '../../Dynatrace-Common/src/util';
 import {version} from "../package.json";
+import {AxiosResponse} from "axios";
+import {
+    Action,
+    exceptions, handlerEvent,
+    LoggerProxy, OperationStatus,
+    Optional,
+    ProgressEvent,
+    ResourceHandlerRequest,
+    SessionProxy
+} from "@amazon-web-services-cloudformation/cloudformation-cli-typescript-lib";
 
 type SyntheticMonitorPayload = {};
 
@@ -10,44 +21,111 @@ type SyntheticMonitorsPayload = {
     monitors: SyntheticMonitorPayload[]
 }
 
-class Resource extends AbstractDynatraceResource<ResourceModel, SyntheticMonitorPayload, SyntheticMonitorPayload, SyntheticMonitorPayload, TypeConfigurationModel> {
+type EventuallyConsistentCallbackContext = {
+    serverTiming?: number
+} & RetryableCallbackContext;
+
+class Resource extends AbstractDynatraceResource<ResourceModel, AxiosResponse<SyntheticMonitorPayload>, AxiosResponse<SyntheticMonitorPayload>, AxiosResponse<SyntheticMonitorPayload>, TypeConfigurationModel> {
 
     private userAgent = `AWS CloudFormation (+https://aws.amazon.com/cloudformation/) CloudFormation resource ${this.typeName}/${version}`;
+    private callbackDelay = 30;
 
-    async get(model: ResourceModel, typeConfiguration?: TypeConfigurationModel): Promise<SyntheticMonitorPayload> {
-        const response = await new DynatraceClient(typeConfiguration?.dynatraceAccess.endpoint, typeConfiguration?.dynatraceAccess.token, this.userAgent).doRequest<SyntheticMonitorPayload>(
+    @handlerEvent(Action.Update)
+    async updateHandler(
+        session: Optional<SessionProxy>,
+        request: ResourceHandlerRequest<ResourceModel>,
+        callbackContext: EventuallyConsistentCallbackContext,
+        logger: LoggerProxy,
+        typeConfiguration: TypeConfigurationModel
+    ): Promise<ProgressEvent<ResourceModel, EventuallyConsistentCallbackContext>> {
+        let model = this.newModel(request.desiredResourceState);
+
+        if (!(await this.assertExists(model, typeConfiguration))) {
+            throw new exceptions.NotFound(this.typeName, request.logicalResourceIdentifier);
+        }
+
+        if (callbackContext.retry && callbackContext.retry > this.maxRetries) {
+            throw new exceptions.NotStabilized(`Resource failed to stabilized after ${this.maxRetries} retries`);
+        }
+
+        if (!callbackContext.serverTiming) {
+            try {
+                let updateResponse = await this.update(model, typeConfiguration);
+                let serverTiming = this.getServerTiming(updateResponse);
+
+                let progressEventBuilder = ProgressEvent.builder<ProgressEvent<ResourceModel, EventuallyConsistentCallbackContext>>()
+                    .status(OperationStatus.InProgress)
+                    .resourceModel(model)
+                    .callbackContext({
+                        serverTiming: serverTiming,
+                        retry: 1
+                    });
+                if (!serverTiming) {
+                    progressEventBuilder.callbackDelaySeconds(this.callbackDelay);
+                }
+                return progressEventBuilder.build();
+            } catch (e) {
+                logger.log(`Error ${e}`);
+                this.processRequestException(e, request);
+            }
+        }
+
+        try {
+            const getResponse = await this.get(model, typeConfiguration);
+            const getServerTiming = this.getServerTiming(getResponse);
+
+            if (callbackContext.serverTiming && getServerTiming < callbackContext.serverTiming) {
+                return ProgressEvent.builder<ProgressEvent<ResourceModel, EventuallyConsistentCallbackContext>>()
+                    .status(OperationStatus.InProgress)
+                    .resourceModel(model)
+                    .callbackContext({
+                        serverTiming: getServerTiming,
+                        retry: callbackContext.retry + 1
+                    }).build();
+            }
+
+            model = this.setModelFrom(model, getResponse);
+            return ProgressEvent.success<ProgressEvent<ResourceModel, EventuallyConsistentCallbackContext>>(model);
+        } catch (e) {
+            if (!callbackContext.serverTiming) {
+                throw new exceptions.NotStabilized(`Resource failed to stabilized after ${this.callbackDelay} seconds: ${e.message}`);
+            } else {
+                this.processRequestException(e, request);
+            }
+        }
+    }
+
+    async get(model: ResourceModel, typeConfiguration?: TypeConfigurationModel): Promise<AxiosResponse<SyntheticMonitorPayload>> {
+        return await new DynatraceClient(typeConfiguration?.dynatraceAccess.endpoint, typeConfiguration?.dynatraceAccess.token, this.userAgent).doRequest<SyntheticMonitorPayload>(
             'get',
             `/api/v1/synthetic/monitors/${model.entityId}`);
-        return response.data;
     }
 
     async list(model: ResourceModel, typeConfiguration?: TypeConfigurationModel): Promise<ResourceModel[]> {
         const response = await new DynatraceClient(typeConfiguration?.dynatraceAccess.endpoint, typeConfiguration?.dynatraceAccess.token, this.userAgent).doRequest<SyntheticMonitorsPayload>(
             'get',
             `/api/v1/synthetic/monitors`);
-        return response.data.monitors.map(monitorPayload => this.setModelFrom(model, monitorPayload))
+        return response.data.monitors.map(monitorPayload => this.setModelFrom(model, {data: monitorPayload} as AxiosResponse<SyntheticMonitorPayload>))
     }
 
-    async create(model: ResourceModel, typeConfiguration?: TypeConfigurationModel): Promise<SyntheticMonitorPayload> {
-        const response = await new DynatraceClient(typeConfiguration?.dynatraceAccess.endpoint, typeConfiguration?.dynatraceAccess.token, this.userAgent).doRequest<SyntheticMonitorPayload>(
+    async create(model: ResourceModel, typeConfiguration?: TypeConfigurationModel): Promise<AxiosResponse<SyntheticMonitorPayload>> {
+        return await new DynatraceClient(typeConfiguration?.dynatraceAccess.endpoint, typeConfiguration?.dynatraceAccess.token, this.userAgent).doRequest<SyntheticMonitorPayload>(
             'post',
             '/api/v1/synthetic/monitors',
             {},
             Transformer.for(model.toJSON())
                 .transformKeys(CaseTransformer.PASCAL_TO_CAMEL)
                 .transform());
-        return response.data;
     }
 
-    async update(model: ResourceModel, typeConfiguration?: TypeConfigurationModel): Promise<SyntheticMonitorPayload> {
-        let response = await new DynatraceClient(typeConfiguration?.dynatraceAccess.endpoint, typeConfiguration?.dynatraceAccess.token, this.userAgent).doRequest<SyntheticMonitorPayload>(
+    async update(model: ResourceModel, typeConfiguration?: TypeConfigurationModel): Promise<AxiosResponse<SyntheticMonitorPayload>> {
+        return await new DynatraceClient(typeConfiguration?.dynatraceAccess.endpoint, typeConfiguration?.dynatraceAccess.token, this.userAgent).doRequest<SyntheticMonitorPayload>(
             'put',
             `/api/v1/synthetic/monitors/${model.entityId}`,
             {},
             Transformer.for(model.toJSON())
                 .transformKeys(CaseTransformer.PASCAL_TO_CAMEL)
                 .transform());
-        return response.data;
     }
 
     async delete(model: ResourceModel, typeConfiguration?: TypeConfigurationModel): Promise<void> {
@@ -60,17 +138,32 @@ class Resource extends AbstractDynatraceResource<ResourceModel, SyntheticMonitor
         return new ResourceModel(partial);
     }
 
-    setModelFrom(model: ResourceModel, from?: SyntheticMonitorPayload): ResourceModel {
-        if (!from) {
+    setModelFrom(model: ResourceModel, from?: AxiosResponse<SyntheticMonitorPayload>): ResourceModel {
+        if (!from.data) {
             return model;
         }
 
         const resourceModel = new ResourceModel({
             ...model,
-            ...from
+            ...from.data
         });
         delete resourceModel.type_;
+        delete resourceModel.anomalyDetection;
+        delete resourceModel.script;
+        delete resourceModel.tags;
+
         return resourceModel;
+    }
+
+    private getServerTiming(response: AxiosResponse<any>) {
+        let serverTiming = undefined;
+        if (response.headers.hasOwnProperty('server-timing')) {
+            const matches = response.headers['server-timing'].match(/dtRpid;desc="([\d\-]+)"/);
+            if (matches !== null) {
+                serverTiming = parseInt(matches[1]);
+            }
+        }
+        return serverTiming;
     }
 
 }

--- a/package.json
+++ b/package.json
@@ -6,14 +6,14 @@
     "doc": "docs"
   },
   "scripts": {
-    "build:all": "find . -depth 1 -type d -name \"*\" -exec bash -c \"test -e {}/.rpdk-config && cd '{}' && cfn generate && npm install && npm run build\" \\;",
+    "build:all": "find . -maxdepth 1 -type d -name \"*\" -exec bash -c \"test -e {}/.rpdk-config && cd '{}' && cfn generate && npm install && npm run build\" \\;",
     "build:docs-clean": "rm -rf docs/user/generated/resources/*",
-    "build:docs-cp-docs": "find . -depth 1 -type d -name \"*\" -exec bash -c \"! test -e {}/.rpdk-config || mkdir -p docs/user/generated/resources/{} && cp {}/docs/* docs/user/generated/resources/{}/\" \\;",
-    "build:docs-cp-extras": "find . -depth 1 -type d -name \"*\" -exec bash -c \"! test -e {}/.rpdk-config || mkdir -p docs/user/generated/resources/{} && cp {}/docs-extra/* docs/user/generated/resources/{}/\" \\;",
+    "build:docs-cp-docs": "find . -maxdepth 1 -type d -name \"*\" -exec bash -c \"! test -e {}/.rpdk-config || mkdir -p docs/user/generated/resources/{} && cp {}/docs/* docs/user/generated/resources/{}/\" \\;",
+    "build:docs-cp-extras": "find . -maxdepth 1 -type d -name \"*\" -exec bash -c \"! test -e {}/.rpdk-config || mkdir -p docs/user/generated/resources/{} && cp {}/docs-extra/* docs/user/generated/resources/{}/\" \\;",
     "build:docs-cp": "cp -r docs/user/src/main/docs/* docs/user/generated",
     "build:docs": "npm run build:docs-clean ; npm run build:docs-cp-docs && npm run build:docs-cp-extras",
     "build": "npm run build:all && npm run build:docs",
-    "test": "find . -depth 1 -type d -name \"*\" -exec bash -c \"test -e {}/jest.config.js && cd '{}' && npm test\" \\;"
+    "test": "find . -maxdepth 1 -type d -name \"*\" -exec bash -c \"test -e {}/jest.config.js && cd '{}' && npm test\" \\;"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This resource is somehow unique. The `read` operation over` update` is eventually consistent. Most of the time, it returns the previous state after an update. So the solution is to look for the header `server-timing` and keep reading until the one returned by the `read` handler is higher than the one from the `update` handler.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.