### PR TITLE
Add prebuild to build common

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "doc": "docs"
   },
   "scripts": {
+    "prebuild:all": "cd Dynatrace-Common && npm install && npm run build",
     "build:all": "find . -maxdepth 1 -type d -name \"*\" -exec bash -c \"test -e {}/.rpdk-config && cd '{}' && cfn generate && npm install && npm run build\" \\;",
     "build:docs-clean": "rm -rf docs/user/generated/resources/*",
     "build:docs-cp-docs": "find . -maxdepth 1 -type d -name \"*\" -exec bash -c \"! test -e {}/.rpdk-config || mkdir -p docs/user/generated/resources/{} && cp {}/docs/* docs/user/generated/resources/{}/\" \\;",


### PR DESCRIPTION
This adds a prebuild script to the top-level package.json to build the common code before building the resources.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.