### PR TITLE
Add AutoAdaptiveThresholdEnabled property

### DIFF
--- a/Dynatrace-Automation-SiteReliabilityGuardian/docs/objective.md
+++ b/Dynatrace-Automation-SiteReliabilityGuardian/docs/objective.md
@@ -15,7 +15,8 @@ To declare this entity in your AWS CloudFormation template, use the following sy
     "<a href="#dqlquery" title="DqlQuery">DqlQuery</a>" : <i>String</i>,
     "<a href="#target" title="Target">Target</a>" : <i>Double</i>,
     "<a href="#warning" title="Warning">Warning</a>" : <i>Double</i>,
-    "<a href="#referenceslo" title="ReferenceSlo">ReferenceSlo</a>" : <i>String</i>
+    "<a href="#referenceslo" title="ReferenceSlo">ReferenceSlo</a>" : <i>String</i>,
+    "<a href="#autoadaptivethresholdenabled" title="AutoAdaptiveThresholdEnabled">AutoAdaptiveThresholdEnabled</a>" : <i>Boolean</i>
 }
 </pre>
 
@@ -30,6 +31,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 <a href="#target" title="Target">Target</a>: <i>Double</i>
 <a href="#warning" title="Warning">Warning</a>: <i>Double</i>
 <a href="#referenceslo" title="ReferenceSlo">ReferenceSlo</a>: <i>String</i>
+<a href="#autoadaptivethresholdenabled" title="AutoAdaptiveThresholdEnabled">AutoAdaptiveThresholdEnabled</a>: <i>Boolean</i>
 </pre>
 
 ## Properties
@@ -117,6 +119,16 @@ _Type_: String
 _Minimum Length_: <code>1</code>
 
 _Maximum Length_: <code>2000</code>
+
+_Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
+
+#### AutoAdaptiveThresholdEnabled
+
+Auto-adaptive thresholds are a dynamic approach to baselining where the reference value for detecting anomalies changes over time. 
+
+_Required_: No
+
+_Type_: Boolean
 
 _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 

--- a/Dynatrace-Automation-SiteReliabilityGuardian/dynatrace-automation-sitereliabilityguardian.json
+++ b/Dynatrace-Automation-SiteReliabilityGuardian/dynatrace-automation-sitereliabilityguardian.json
@@ -94,6 +94,11 @@
                     "description": "Please enter the metric key of your desired SLO. SLO metric keys have to start with 'func:slo.'",
                     "maxLength": 2000,
                     "minLength": 1
+                },
+                "AutoAdaptiveThresholdEnabled": {
+                    "type": "boolean",
+                    "description": "Auto-adaptive thresholds are a dynamic approach to baselining where the reference value for detecting anomalies changes over time. "
+
                 }
             },
             "required": [

--- a/Dynatrace-Automation-SiteReliabilityGuardian/src/models.ts
+++ b/Dynatrace-Automation-SiteReliabilityGuardian/src/models.ts
@@ -174,6 +174,15 @@ export class Objective extends BaseModel {
         }
     )
     referenceSlo?: Optional<string>;
+    @Expose({ name: 'AutoAdaptiveThresholdEnabled' })
+    @Transform(
+        (value: any, obj: any) =>
+            transformValue(Boolean, 'autoAdaptiveThresholdEnabled', value, obj, []),
+        {
+            toClassOnly: true,
+        }
+    )
+    autoAdaptiveThresholdEnabled?: Optional<boolean>;
 
 }
 

--- a/README.md
+++ b/README.md
@@ -10,9 +10,6 @@ See the [end-user documentation](docs/user/src/main/docs) including:
 There is also [developer documentation](docs/dev) available
 if you are interested in building or contributing.
 
-There is also [developer documentation](docs/dev) available
-if you are interested in building or contributing.
-
 | Resource | Description | Documentation |
 | --- | --- | --- |
 | Dynatrace::Configuration::Dashboard | This resource type manages a [Dynatrace Dashboard][3] | [/Dynatrace-Configuration-Dashboard][4] |

--- a/docs/user/generated/resources/Dynatrace-Environment-SyntheticMonitor/eventsinput.md
+++ b/docs/user/generated/resources/Dynatrace-Environment-SyntheticMonitor/eventsinput.md
@@ -53,13 +53,13 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 
 #### Type
 
-The type of synthetic event. Depending on the value slected here, different parameters will be considered, see reference for more info: https://docs.dynatrace.com/docs/platform-modules/digital-experience/synthetic-monitoring/browser-monitors/script-mode-for-browser-monitor-configuration
+The type of synthetic event. Depending on the value selected here, different parameters will be considered, see reference for more info: https://docs.dynatrace.com/docs/platform-modules/digital-experience/synthetic-monitoring/browser-monitors/script-mode-for-browser-monitor-configuration
 
 _Required_: No
 
 _Type_: String
 
-_Allowed Values_: <code>navigate</code> | <code>click</code> | <code>tap</code> | <code>javascript</code> | <code>seclectOption</code> | <code>cookie</code> | <code>keystrokes</code>
+_Allowed Values_: <code>navigate</code> | <code>click</code> | <code>tap</code> | <code>javascript</code> | <code>selectOption</code> | <code>cookie</code> | <code>keystrokes</code>
 
 _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 

--- a/docs/user/generated/resources/Dynatrace-Environment-SyntheticMonitor/globaloutagepolicy.md
+++ b/docs/user/generated/resources/Dynatrace-Environment-SyntheticMonitor/globaloutagepolicy.md
@@ -26,7 +26,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 
 Alert if all locations are unable to access the web application X times consecutively.
 
-_Required_: Yes
+_Required_: No
 
 _Type_: Integer
 

--- a/docs/user/generated/resources/Dynatrace-Environment-SyntheticMonitor/localoutagepolicy.md
+++ b/docs/user/generated/resources/Dynatrace-Environment-SyntheticMonitor/localoutagepolicy.md
@@ -30,7 +30,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 
 The number of affected locations to trigger an alert.
 
-_Required_: Yes
+_Required_: No
 
 _Type_: Integer
 
@@ -40,7 +40,7 @@ _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormati
 
 The number of consecutive fails to trigger an alert.
 
-_Required_: Yes
+_Required_: No
 
 _Type_: Integer
 

--- a/docs/user/src/main/docs/stories/automating-stuff/README.md
+++ b/docs/user/src/main/docs/stories/automating-stuff/README.md
@@ -21,3 +21,43 @@ aws cloudformation deploy \
   --stack-name Dynatrace-Six-Pillars \
   --template-file dynatrace-six-pillars.yaml
 ```
+
+
+Steps:
+- register type (if not published)
+  - `npm run build` - top level (requires cfn cl and aws cli and node)
+    - cfn - `pip install cloudformation-cli cloudformation-cli-java-plugin cloudformation-cli-typescript-plugin`
+    - aws ??? - (https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html)
+  - per resource e.g `cd Dynatrace-Automation-Workflow` && `cfn submit --set-default -v --region eu-west-1`
+    - activate type (if publised - you don't need this if your did the step above)
+      - Registry -> Public extensions
+        - Third party - search DT
+          - activate
+            - Needs IAM Execution role - ????
+            -  configuration - ```json
+            {
+                  "DynatraceOAuthAccess": {
+                  "ClientId": "{{resolve:ssm-secure:/cfn/dynatrace/oauth/clientid}}",
+                  "ClientSecret": "{{resolve:ssm-secure:/cfn/dynatrace/oauth/clientsecret}}",
+                  "Endpoint": "{{resolve:ssm-secure:/cfn/dynatrace/oauth/live-endpoint}}"
+                  }
+                }
+            ```
+- setup ssm keys
+  - AWS Systems Manager Parameter store
+    - /cfn/dynatrace/oauth/clientid 
+    - /cfn/dynatrace/oauth/clientsecret
+    - /cfn/dynatrace/oauth/live-endpoint
+- Deploy using commmand above
+  - ```bash
+    aws cloudformation deploy \
+  --region eu-west-1 \
+  --stack-name Dynatrace-Six-Pillars \
+  --template-file dynatrace-six-pillars.yaml
+  ```
+- Or Deploy through UI
+  - Cloudforamtaion
+  - Stacks (top right)
+  - Create Stack
+  - Select template file
+  - 

--- a/docs/user/src/main/docs/stories/automating-stuff/dynatrace-six-pillars.yaml
+++ b/docs/user/src/main/docs/stories/automating-stuff/dynatrace-six-pillars.yaml
@@ -45,10 +45,7 @@ Resources:
       Name:        My new real-user experience objective
       Description: This is an Apdex rating experience SLO
       MetricName:  !Ref ApdexRatingSloMetricName
-      MetricExpression: |
-        (100)
-        * (builtin:apps.web.actionCount.category:filter(eq("Apdex category",SATISFIED)):splitBy())
-        / (builtin:apps.web.actionCount.category:splitBy())
+      MetricExpression: '(100)*(builtin:apps.web.actionCount.category:filter(eq("Apdex category",SATISFIED)):splitBy())/(builtin:apps.web.actionCount.category:splitBy())'
       Timeframe:   -1w
       Filter:      'type("APPLICATION"),entityName.equals("myApplication")'
       Target:      !Ref TargetApdexRating
@@ -126,6 +123,7 @@ Resources:
       Objectives:
         - Name:          Availability validation
           Description:   Success Rate – Availability Validation with Synthetic Monitoring
+          AutoAdaptiveThresholdEnabled: True
           ObjectiveType: DQL
           ComparisonOperator: LESS_THAN_OR_EQUAL
           Target:        !Ref TargetAvailability

--- a/docs/user/src/main/docs/stories/starting-a-project/example.yaml
+++ b/docs/user/src/main/docs/stories/starting-a-project/example.yaml
@@ -16,7 +16,7 @@ Resources:
   TimeToCompletionMetric:
     Type: Dynatrace::Environment::Metric
     Properties:
-      Id: custom:kpis.timeToCompletion
+      TimeseriesId: custom:kpis.timeToCompletion
       DisplayName: Average time for a customer to complete the sales process, from cart
       Unit: Second (s)
       Dimensions:
@@ -27,7 +27,7 @@ Resources:
   SuccessCountMetric:
     Type: Dynatrace::Environment::Metric
     Properties:
-      Id: custom:kpis.successCount
+      TimeseriesId: custom:kpis.successCount
       DisplayName: Number of people having something in their cart and completing the sale
       Unit: Count (count)
       Dimensions:
@@ -38,7 +38,7 @@ Resources:
   DropCountMetric:
     Type: Dynatrace::Environment::Metric
     Properties:
-      Id: custom:kpis.dropCount
+      TimeseriesId: custom:kpis.dropCount
       DisplayName: Number of people having something in their cart, to failing to complete the sale
       Unit: Count (count)
       Dimensions:
@@ -81,19 +81,19 @@ Resources:
             - Type: TOTAL
               ValueMs: 100
       Script:
-        version: 1.0
-        requests:
-          - url: https://aws.amazon.com
-            method: GET
-            description: HTTP request test
-            validation:
-              rules:
-                - type: httpStatusesList
-                  value: 500, 400
-                  passIfFound: false
-                - type: httpStatusesList
-                  value: 200, 204, 302
-                  passIfFound: true
+        Version: 1.0
+        Requests:
+          - Url: https://aws.amazon.com
+            Method: GET
+            Description: HTTP request test
+            Validation:
+              Rules:
+                - Type: httpStatusesList
+                  Value: 500, 400
+                  PassIfFound: false
+                - Type: httpStatusesList
+                  Value: 200, 204, 302
+                  PassIfFound: true
       Locations:
         - !Ref ActiveGateLocation
 
@@ -126,54 +126,54 @@ Resources:
           - CloudFormation
           - Dynatrace
       Tiles:
-        - name: Sales failure
-          tileType: SLO
-          configured: true
-          bounds:
-            top: 0
-            left: 0
-            width: 304
-            height: 152
-          tileFilter:
-            timeframe: -1w
-          assignedEntities:
+        - Name: Sales failure
+          TileType: SLO
+          Configured: true
+          Bounds:
+            Top: 0
+            Left: 0
+            Width: 304
+            Height: 152
+          TileFilter:
+            Timeframe: -1w
+          AssignedEntities:
             - !Ref SaleFailureServiceLevelObjective
-          metric: METRICS=true;LEGEND=true;PROBLEMS=true;decimals=10;customTitle=Overall sale failure;
-        - name: Uptime
-          tileType: SYNTHETIC_HTTP_MONITOR
-          configured: true
-          bounds:
-            top: 0
-            left: 304
-            width: 304
-            height: 304
-          assignedEntities:
+          Metric: METRICS=true;LEGEND=true;PROBLEMS=true;decimals=10;customTitle=Overall sale failure;
+        - Name: Uptime
+          TileType: SYNTHETIC_HTTP_MONITOR
+          Configured: true
+          Bounds:
+            Top: 0
+            Left: 304
+            Width: 304
+            Height: 304
+          AssignedEntities:
             - !Ref HealthMonitor
-        - name: Completion time
-          tileType: DATA_EXPLORER
-          configured: true
-          bounds:
-            top: 152
-            left: 0
-            width: 304
-            height: 304
-          customName: Data explorer results
-          queries:
-            - id: A
-              metric: ext:kpis.timeToCompletion
-              timeAggregation: DEFAULT
-              sortBy: DESC
-              limit: 100
-              enabled: true
-          visualConfig:
-            type: GRAPH_CHART
-            global:
-              hideLegend: false
-            rules:
-              - matcher: "A:"
-                properties:
-                  color: DEFAULT
-            axes:
+        - Name: Completion time
+          TileType: DATA_EXPLORER
+          Configured: true
+          Bounds:
+            Top: 152
+            Left: 0
+            Width: 304
+            Height: 304
+          CustomName: Data explorer results
+          Queries:
+            - Id: A
+              Metric: ext:kpis.timeToCompletion
+              TimeAggregation: DEFAULT
+              SortBy: DESC
+              Limit: 100
+              Enabled: true
+          VisualConfig:
+            Type: GRAPH_CHART
+            Global:
+              HideLegend: false
+            Rules:
+              - Matcher: "A:"
+                Properties:
+                  Color: DEFAULT
+            Axes:
               xAxis:
                 displayName: ""
                 visible: true


### PR DESCRIPTION
Add AutoAdaptiveThresholdEnabled property
This extends the Site Reliability Guardian objective with a flag to enable the Auto Adaptive Threshold

Tested with a manual deployment and by manually running contract tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

