### PR TITLE
SRG resource to use apps endpoint

### DIFF
--- a/Dynatrace-Automation-SiteReliabilityGuardian/src/handlers.ts
+++ b/Dynatrace-Automation-SiteReliabilityGuardian/src/handlers.ts
@@ -24,7 +24,7 @@ class Resource extends AbstractDynatraceResource<ResourceModel, SRGPayload, SRGP
     async get(model: ResourceModel, typeConfiguration?: TypeConfigurationModel): Promise<SRGPayload> {
         const response = await this.newOauthClient(typeConfiguration, ["app-engine:apps:run", "settings:objects:read"]).doRequest<SRGPayload>(
             'get',
-            `/api/v2/settings/objects/${model.objectId}`);
+            `/platform/classic/environment-api/v2/settings/objects/${model.objectId}`);
 
         return response.data;
     }
@@ -32,7 +32,7 @@ class Resource extends AbstractDynatraceResource<ResourceModel, SRGPayload, SRGP
     async list(model: ResourceModel, typeConfiguration?: TypeConfigurationModel): Promise<ResourceModel[]> {
         return await this.newOauthClient(typeConfiguration, ["app-engine:apps:run", "settings:objects:read"]).paginate<SRGsPayload, ResourceModel>(
             'get',
-            `/api/v2/settings/objects?schemaIds=app:dynatrace.site.reliability.guardian:guardians`,
+            `/platform/classic/environment-api/v2/settings/objects?schemaIds=app:dynatrace.site.reliability.guardian:guardians`,
             pagedResponse => pagedResponse.data
                 ? pagedResponse.data.items.map(srg => this.setModelFrom(model, srg))
                 : []);
@@ -41,7 +41,7 @@ class Resource extends AbstractDynatraceResource<ResourceModel, SRGPayload, SRGP
     async create(model: ResourceModel, typeConfiguration?: TypeConfigurationModel): Promise<SRGPayload> {
         const response = await this.newOauthClient(typeConfiguration, ["settings:objects:write", "app-engine:apps:run"]).doRequest<SRGPayload[]>(
             'post',
-            `/api/v2/settings/objects`,
+            `/platform/classic/environment-api/v2/settings/objects`,
             {},
             [{
                 value: Transformer.for(model.toJSON())
@@ -65,7 +65,7 @@ class Resource extends AbstractDynatraceResource<ResourceModel, SRGPayload, SRGP
 
         const response = await this.newOauthClient(typeConfiguration, ["settings:objects:write", "app-engine:apps:run"]).doRequest<SRGPayload>(
             'put',
-            `/api/v2/settings/objects/${model.objectId}`,
+            `/platform/classic/environment-api/v2/settings/objects/${model.objectId}`,
             {},
             body);
         return response.data;
@@ -74,7 +74,7 @@ class Resource extends AbstractDynatraceResource<ResourceModel, SRGPayload, SRGP
     async delete(model: ResourceModel, typeConfiguration?: TypeConfigurationModel): Promise<void> {
         await this.newOauthClient(typeConfiguration, ["settings:objects:write", "app-engine:apps:run"]).doRequest<SRGPayload>(
             'delete',
-            `/api/v2/settings/objects/${model.objectId}`);
+            `/platform/classic/environment-api/v2/settings/objects/${model.objectId}`);
     }
 
     newModel(partial?: any): ResourceModel {

--- a/docs/user/src/main/docs/README.md
+++ b/docs/user/src/main/docs/README.md
@@ -16,7 +16,10 @@ In the AWS CloudFormation UI, find the Dynatrace types in the third-party regist
 Alternatively follow the [Developer](docs/dev) instructions to install them manually.
 
 You will need to set up a [Type Configuration](https://awscli.amazonaws.com/v2/documentation/api/latest/reference/cloudformation/set-type-configuration.html)
-for each of the activated types, containing a Dynatrace **Access Token** as well as the Dynatrace **endpoint** to reach.
+for each of the activated types.
+
+The Dynatrace::Automation::* and Dynatrace::Environment::* resources use the classic api requiring 
+a Dynatrace **Access Token** as well as the Dynatrace **Endpoint** to reach.
 It is recommended to set both of these into Systems Manager's secure parameter store,
 e.g. as `/path/to/dynatrace/token` and `/path/to/dynatrace/endpoint`, and then it can be applied any of the Dynatrace type,
 e.g. `Dynatrace::Configuration::Dashboard`, using:
@@ -30,7 +33,21 @@ aws cloudformation set-type-configuration \
 --configuration '{"DynatraceAccess": {"Token": "{{resolve:ssm-secure:/path/to/dynatrace/token}}", "Endpoint": "{{resolve:ssm-secure:/path/to/dynatrace/endpoint}}"}}'
 ```
 
-You should then be able to run the example use cases above or build your own using the full reference below.
+The Dynatrace::Automation::* resources use the apps endpoint requiring a Dynatrace **Client Id**, a 
+**Client Secret** and a Dynatrace apps **Endpoint**.
+
+e.g.
+
+```
+aws cloudformation set-type-configuration \
+--region eu-north-1 \
+--type RESOURCE \
+--type-name Dynatrace::Automation::SiteReliabilityGuardian \
+--configuration-alias default \
+--configuration '{"DynatraceOAuthAccess": {"ClientId": "{{resolve:ssm-secure:/cfn/dynatrace/oauth/clientid}}", "ClientSecret": "{{resolve:ssm-secure:/cfn/dynatrace/oauth/clientsecret}}","Endpoint": "{{resolve:ssm-secure:/cfn/dynatrace/oauth/apps-endpoint}}"}}'
+```
+
+You should then be able to run the examples use cases above or build your own using the full reference below.
 
 ### What is supported?
 


### PR DESCRIPTION
This was previously using the live endpoint with OAuth but OAuth apps should use apps endpoint.
This requires a different path.

This is a breaking change but as the AWS::Automation::SiteReliabilityGuardian resource has not been published this is probably ok to merge.

After merging this PR type configuration for SRG will need to be updated to used the same endpoint as the Workflow resource.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.